### PR TITLE
feat(prophet): clone git repos and convert to source-code-parser Directory

### DIFF
--- a/prophet-ressa-minify/Cargo.toml
+++ b/prophet-ressa-minify/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-source-code-parser = { git = "https://github.com/cloudhubs/source-code-parser", rev = "3a1e045" }
+source-code-parser = { git = "https://github.com/cloudhubs/source-code-parser", rev = "b30be50" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 thiserror = "1.0.29"

--- a/prophet-ressa-minify/Cargo.toml
+++ b/prophet-ressa-minify/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-source-code-parser = { git = "https://github.com/cloudhubs/source-code-parser", rev = "2153814" }
+source-code-parser = { git = "https://github.com/cloudhubs/source-code-parser", rev = "3a1e045" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 thiserror = "1.0.29"

--- a/prophet/Cargo.toml
+++ b/prophet/Cargo.toml
@@ -11,4 +11,4 @@ git2 = "0.13"
 tracing = "0.1.26"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
-source-code-parser = { git = "https://github.com/cloudhubs/source-code-parser", rev = "3a1e045" }
+source-code-parser = { git = "https://github.com/cloudhubs/source-code-parser", rev = "b30be50" }

--- a/prophet/Cargo.toml
+++ b/prophet/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2021"
 
 [dependencies]
 prophet-ressa = { path = "../prophet-ressa" }
+git2 = "0.13"
+tracing = "0.1.26"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
+source-code-parser = { git = "https://github.com/cloudhubs/source-code-parser", rev = "3a1e045" }

--- a/prophet/src/lib.rs
+++ b/prophet/src/lib.rs
@@ -69,10 +69,7 @@ fn get_dir_contents(root_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>), std
 
 /// Convers the given root directory into its Directory representation
 fn convert_sub_dir(root_dir: PathBuf) -> Option<Directory> {
-    let (files, sub_dir_paths) = match get_dir_contents(&root_dir) {
-        Ok(contents) => contents,
-        _ => return None,
-    };
+    let (files, sub_dir_paths) = get_dir_contents(&root_dir).map_or(None, Some)?;
 
     let sub_directories = convert_sub_dirs(sub_dir_paths);
 

--- a/prophet/src/lib.rs
+++ b/prophet/src/lib.rs
@@ -69,7 +69,7 @@ fn get_dir_contents(root_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>), std
 
 /// Convers the given root directory into its Directory representation
 fn convert_sub_dir(root_dir: PathBuf) -> Option<Directory> {
-    let (files, sub_dir_paths) = get_dir_contents(&root_dir).map_or(None, Some)?;
+    let (files, sub_dir_paths) = get_dir_contents(&root_dir).ok()?;
 
     let sub_directories = convert_sub_dirs(sub_dir_paths);
 

--- a/prophet/src/lib.rs
+++ b/prophet/src/lib.rs
@@ -1,8 +1,9 @@
 //! A library for cloning microservice git repositories and
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use git2::Repository;
 use serde::Deserialize;
+use source_code_parser::Directory;
 
 /// A cloned microservice or microservice system repository
 #[derive(Default, Deserialize)]
@@ -38,6 +39,76 @@ impl Drop for MicroservicesRepository {
     }
 }
 
+/// Gets the subdirectories and files from a directory `&Path`
+fn get_dir_contents(root_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>), std::io::Error> {
+    let read_dir = match std::fs::read_dir(&root_dir) {
+        Ok(dir) => dir,
+        Err(err) => {
+            tracing::warn!("Could not read directory: {:?}", err);
+            return Err(err);
+        }
+    };
+
+    let mut files = vec![];
+    let mut sub_dirs = vec![];
+
+    for entry in read_dir {
+        let entry = entry?;
+        let entry_path = entry.path();
+
+        if entry_path.is_dir() {
+            sub_dirs.push(entry_path);
+            continue;
+        }
+
+        files.push(entry_path);
+    }
+
+    Ok((files, sub_dirs))
+}
+
+/// Convers the given root directory into its Directory representation
+fn convert_sub_dir(root_dir: PathBuf) -> Option<Directory> {
+    let (files, sub_dir_paths) = match get_dir_contents(&root_dir) {
+        Ok(contents) => contents,
+        _ => return None,
+    };
+
+    let sub_directories = convert_sub_dirs(sub_dir_paths);
+
+    Some(Directory::new(files, sub_directories, root_dir))
+}
+
+/// Converts the paths into their Directory representations
+fn convert_sub_dirs(sub_dirs: Vec<PathBuf>) -> Vec<Directory> {
+    sub_dirs.into_iter().flat_map(convert_sub_dir).collect()
+}
+
+impl From<MicroservicesRepository> for Directory {
+    /// Create a Directory structure from a cloned microservice(s) repository
+    fn from(repo: MicroservicesRepository) -> Self {
+        // Convert into the Directory type from the given MS repository
+        let root_dirs = repo
+            .root_dirs
+            .iter()
+            .map(|relative_path| {
+                let mut root = repo.clone_dir.clone();
+                root.push(relative_path);
+                root
+            })
+            .flat_map(convert_sub_dir)
+            .collect();
+
+        // Get the files in the root directory
+        let files = match get_dir_contents(&repo.clone_dir.clone()) {
+            Ok((files, _)) => files,
+            _ => vec![],
+        };
+
+        Directory::new(files, root_dirs, repo.clone_dir.clone())
+    }
+}
+
 /// The cloned repositories for the microservices to statically analyze
 ///
 /// The serialized representation in JSON is as follows
@@ -53,19 +124,19 @@ impl Drop for MicroservicesRepository {
 #[derive(Deserialize)]
 pub struct Repositories(Vec<MicroservicesRepository>);
 
-impl From<Repositories> for source_code_parser::Directory {
+impl From<Repositories> for Directory {
     /// Create a Directory structure from cloned microservice repositories
-    fn from((_repostories): Repositories) -> Self {
+    fn from(repositories: Repositories) -> Self {
         // Convert into the Directory type from the given
         // repositories and root directories for each
+        let sub_directories = repositories
+            .0
+            .into_iter()
+            .map(MicroservicesRepository::into)
+            .collect::<Vec<Directory>>();
 
-        // TODO add new() method to this type or make its fields pub
-        // source_code_parser::Directory {
-        //     files: vec![],
-        //     sub_directories: vec![],
-        //     path: "".into(),
-        // }
-        todo!()
+        // Create a fake top-level directory
+        Directory::new(vec![], sub_directories, "".into())
     }
 }
 

--- a/prophet/src/lib.rs
+++ b/prophet/src/lib.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use source_code_parser::Directory;
 
 /// A cloned microservice or microservice system repository
-#[derive(Default, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct MicroservicesRepository {
     /// The Git URL of the repository to clone from
     pub git_url: String,
@@ -121,7 +121,7 @@ impl From<MicroservicesRepository> for Directory {
 ///   }
 /// ]
 /// ```
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Repositories(Vec<MicroservicesRepository>);
 
 impl From<Repositories> for Directory {

--- a/prophet/src/lib.rs
+++ b/prophet/src/lib.rs
@@ -53,10 +53,9 @@ impl Drop for MicroservicesRepository {
 #[derive(Deserialize)]
 pub struct Repositories(Vec<MicroservicesRepository>);
 
-impl Into<source_code_parser::Directory> for Repositories {
-    fn into(self) -> source_code_parser::Directory {
-        let (repositories) = self.0;
-
+impl From<Repositories> for source_code_parser::Directory {
+    /// Create a Directory structure from cloned microservice repositories
+    fn from((_repostories): Repositories) -> Self {
         // Convert into the Directory type from the given
         // repositories and root directories for each
 

--- a/prophet/src/lib.rs
+++ b/prophet/src/lib.rs
@@ -1,8 +1,83 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
+//! A library for cloning microservice git repositories and
+use std::path::PathBuf;
+
+use git2::Repository;
+use serde::Deserialize;
+
+/// A cloned microservice or microservice system repository
+#[derive(Default, Deserialize)]
+pub struct MicroservicesRepository {
+    /// The Git URL of the repository to clone from
+    pub git_url: String,
+    /// The root directories to include source code files from in static analysis,
+    /// relative to `clone_dir`
+    pub root_dirs: Vec<PathBuf>,
+    /// The local directory the repository was cloned to
+    pub clone_dir: PathBuf,
+}
+
+impl MicroservicesRepository {
+    /// Clones a microservice(s) repository
+    pub fn clone(&mut self) -> Result<(), git2::Error> {
+        Repository::clone(&self.git_url, &self.clone_dir)?;
+        Ok(())
     }
 }
+
+impl Drop for MicroservicesRepository {
+    /// Clean the cloned repository when freeing the repository from memory
+    fn drop(&mut self) {
+        if let Err(err) = std::fs::remove_dir_all(&self.clone_dir) {
+            tracing::warn!(
+                "Failed to remove cloned repository '{}' at '{:?}': {:?}",
+                self.git_url,
+                self.clone_dir,
+                err
+            );
+        }
+    }
+}
+
+/// The cloned repositories for the microservices to statically analyze
+///
+/// The serialized representation in JSON is as follows
+/// ```json
+/// [
+///   {
+///      "git_url": "https://github.com/some/repository.git",
+///      "root_dirs": ["some/relative", "./paths/here"],
+///      "clone_dir": "/path/to/the/cloned/repo"
+///   }
+/// ]
+/// ```
+#[derive(Deserialize)]
+pub struct Repositories(Vec<MicroservicesRepository>);
+
+impl Into<source_code_parser::Directory> for Repositories {
+    fn into(self) -> source_code_parser::Directory {
+        let (repositories) = self.0;
+
+        // Convert into the Directory type from the given
+        // repositories and root directories for each
+
+        // TODO add new() method to this type or make its fields pub
+        // source_code_parser::Directory {
+        //     files: vec![],
+        //     sub_directories: vec![],
+        //     path: "".into(),
+        // }
+        todo!()
+    }
+}
+
+impl Repositories {
+    /// Clones all of the microservice(s) repositories
+    pub fn clone_all(&mut self) -> Result<(), git2::Error> {
+        for repo in self.0.iter_mut() {
+            repo.clone()?;
+        }
+        Ok(())
+    }
+}
+
+// TODO implement getProphetAppData equivalent


### PR DESCRIPTION
This PR implements part of #7 -- specifically the part for cloning a repository and converting it to a `Directory` for usage as input with a ReSSA in `source-code-parser`