### PR TITLE
feat(prophet-service): Add REST API to analyze repositories

### DIFF
--- a/prophet-service/Cargo.toml
+++ b/prophet-service/Cargo.toml
@@ -7,3 +7,9 @@ edition = "2021"
 
 [dependencies]
 prophet = { path = "../prophet" }
+structopt = "0.3.25"
+actix-web = "3.3.2"
+env_logger = "0.9.0"
+tracing = { version = "0.1.29", features = ["log"] }
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"

--- a/prophet-service/src/main.rs
+++ b/prophet-service/src/main.rs
@@ -1,3 +1,33 @@
-fn main() {
-    println!("Hello, world!");
+use actix_web::{middleware::Logger, web, App, FromRequest, HttpServer};
+use prophet::Repositories;
+use structopt::StructOpt;
+
+mod routes;
+use routes::*;
+
+#[derive(StructOpt)]
+struct Opt {
+    #[structopt(long, short, default_value = "127.0.0.1")]
+    host: String,
+    #[structopt(long, short, default_value = "8080")]
+    port: i32,
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+    let opt = Opt::from_args();
+    let addr = format!("{}:{}", opt.host, opt.port);
+
+    HttpServer::new(|| {
+        App::new()
+            .service(analyze)
+            .wrap(Logger::default())
+            .app_data(web::Json::<Repositories>::configure(|cfg| {
+                cfg.limit(1024 * 1024 * 4)
+            }))
+    })
+    .bind(addr)?
+    .run()
+    .await
 }

--- a/prophet-service/src/routes.rs
+++ b/prophet-service/src/routes.rs
@@ -1,0 +1,9 @@
+use actix_web::{error, post, web, Error, HttpResponse};
+use prophet::{AppData, Repositories};
+
+#[post("/analyze")]
+pub async fn analyze(payload: web::Json<Repositories>) -> Result<HttpResponse, Error> {
+    let app_data = AppData::from_repositories(payload.into_inner())
+        .map_err(error::ErrorInternalServerError)?;
+    Ok(HttpResponse::Ok().json(app_data))
+}


### PR DESCRIPTION
Resolves #8. Not all of `prophet` and co. subcrates have been implemented yet but this may prove helpful in debugging (though we should be writing unit tests for some of these where possible)